### PR TITLE
Add opflex subiface mtu parameter

### DIFF
--- a/tripleo-ciscoaci/files/service-ciscoaci.yaml
+++ b/tripleo-ciscoaci/files/service-ciscoaci.yaml
@@ -65,6 +65,9 @@ parameters:
   ACIOpflexUplinkInterface:
     type: string
     default: 'nic1'
+  ACIOpflexUplinkInterfaceMTU:
+    type: number
+    default: '9000'
   ACIOpflexBridgeToPatch:
     type: string
     default: 'br-ex'
@@ -219,6 +222,7 @@ outputs:
             ciscoaci::opflex::aci_apic_infra_subnet_gateway: {get_param: ACIApicInfraSubnetGateway}
             ciscoaci::opflex::aci_apic_infra_anycast_address: {get_param: ACIApicInfraAnycastAddr}    
             ciscoaci::opflex::aci_opflex_uplink_interface: {get_param: ACIOpflexUplinkInterface}
+            ciscoaci::opflex::aci_apic_uplink_interface_mtu: {get_param: ACIOpflexUplinkInterfaceMTU}
             ciscoaci::opflex::aci_opflex_encap_mode: {get_param: ACIOpflexEncapMode}
             ciscoaci::opflex::opflex_target_bridge_to_patch: {get_param: ACIOpflexBridgeToPatch}
             ciscoaci::aim::use_openvswitch: {get_param: AciOpenvswitch}


### PR DESCRIPTION
This PR needs https://github.com/noironetworks/ciscoaci-puppet/pull/4 in the Cisco ACI puppet modules.