### PR TITLE
Add ability to disable opflex-agent features

### DIFF
--- a/tripleo-ciscoaci/puppet/services/ciscoaci-aim.yaml
+++ b/tripleo-ciscoaci/puppet/services/ciscoaci-aim.yaml
@@ -78,6 +78,13 @@ parameters:
       Valid values are 'linux' or 'ovs'. This determines whether the infra vlan interface
       is created as a linux interface or an OVS interface. For openshift on openstack, the
       interface should be a OVS interface.
+  ACIOpflexDisabledFeatures:
+    type: comma_delimited_list
+    default: "erspan"
+    description: >
+      Valid values are "erspan". This determines whether a given feature is supported
+      by the vSwitch in the underlying distribution, and therefore can be enabled in the
+      opflex-agent.
   ACIOpflexInterfaceMTU:
     type: number
     default: 1600
@@ -253,6 +260,7 @@ outputs:
             ciscoaci::opflex::aci_apic_infra_anycast_address: {get_param: ACIApicInfraAnycastAddr}    
             ciscoaci::opflex::aci_opflex_uplink_interface: {get_param: ACIOpflexUplinkInterface}
             ciscoaci::opflex::aci_opflex_encap_mode: {get_param: ACIOpflexEncapMode}
+            ciscoaci::opflex::opflex_disabled_features: {get_param: ACIOpflexDisabledFeatures}
             ciscoaci::opflex::opflex_target_bridge_to_patch: {get_param: ACIOpflexBridgeToPatch}
             ciscoaci::opflex::opflex_interface_type: {get_param: ACIOpflexInterfaceType}
             ciscoaci::opflex::opflex_interface_mtu: {get_param: ACIOpflexInterfaceMTU}

--- a/tripleo-ciscoaci/puppet/services/ciscoaci-ml2.yaml
+++ b/tripleo-ciscoaci/puppet/services/ciscoaci-ml2.yaml
@@ -72,6 +72,13 @@ parameters:
       Valid values are 'linux' or 'ovs'. This determines whether the infra vlan interface
       is created as a linux interface or an OVS interface. For openshift on openstack, the
       interface should be a OVS interface.
+  ACIOpflexDisabledFeatures:
+    type: comma_delimited_list
+    default: "erspan"
+    description: >
+      Valid values are "erspan". This determines whether a given feature is supported
+      by the vSwitch in the underlying distribution, and therefore can be enabled in the
+      opflex-agent.
   ACIOpflexInterfaceMTU:
     type: number
     default: 1600
@@ -236,6 +243,7 @@ outputs:
             ciscoaci::opflex::aci_apic_infra_anycast_address: {get_param: ACIApicInfraAnycastAddr}    
             ciscoaci::opflex::aci_opflex_uplink_interface: {get_param: ACIOpflexUplinkInterface}
             ciscoaci::opflex::aci_opflex_encap_mode: {get_param: ACIOpflexEncapMode}
+            ciscoaci::opflex::opflex_disabled_features: {get_param: ACIOpflexDisabledFeatures}
             ciscoaci::opflex::opflex_target_bridge_to_patch: {get_param: ACIOpflexBridgeToPatch}
             ciscoaci::opflex::opflex_interface_type: {get_param: ACIOpflexInterfaceType}
             ciscoaci::opflex::opflex_interface_mtu: {get_param: ACIOpflexInterfaceMTU}

--- a/tripleo-ciscoaci/puppet/services/ciscoaci_compute.yaml
+++ b/tripleo-ciscoaci/puppet/services/ciscoaci_compute.yaml
@@ -52,6 +52,13 @@ parameters:
       Valid values are 'linux' or 'ovs'. This determines whether the infra vlan interface
       is created as a linux interface or an OVS interface. For openshift on openstack, the
       interface should be a OVS interface.
+  ACIOpflexDisabledFeatures:
+    type: string
+    default: "erspan"
+    description: >
+      Valid values are "erspan". This determines whether a given feature is supported
+      by the vSwitch in the underlying distribution, and therefore can be enabled in the
+      opflex-agent.
   ACIOpflexInterfaceMTU:
     type: number
     default: 1600
@@ -150,6 +157,7 @@ outputs:
             ciscoaci::opflex::aci_apic_infra_anycast_address: {get_param: ACIApicInfraAnycastAddr}    
             ciscoaci::opflex::aci_opflex_uplink_interface: {get_param: ACIOpflexUplinkInterface}
             ciscoaci::opflex::aci_opflex_encap_mode: {get_param: ACIOpflexEncapMode}
+            ciscoaci::opflex::opflex_disabled_features: {get_param: ACIOpflexDisabledFeatures}
             ciscoaci::opflex::opflex_enable_bond_watch: {get_param: ACIEnableBondWatchService}
             ciscoaci::opflex::opflex_target_bridge_to_patch: {get_param: ACIOpflexBridgeToPatch}
             ciscoaci::opflex::opflex_interface_type: {get_param: ACIOpflexInterfaceType}


### PR DESCRIPTION
The opflex-agent is dependent on the vSwitch from the underling
distribution. Some distributions ship older versions of the vSwitch
which aren't capable of supporting new features in the opflex-agent,
and therefore those features have to be disabled. This patch adds
a new configuration item for this, which provides a string with a
comma-delimited list inside for the features that should be
disabled in the deployment.

The initial feature disabled is ERSPAN.