### PR TITLE
Enable ERSPAN by default

### DIFF
--- a/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
@@ -104,7 +104,7 @@ parameters:
       interface should be a OVS interface.
   ACIOpflexDisabledFeatures:
     type: comma_delimited_list
-    default: "erspan"
+    default: ""
     description: >
       Valid values are "erspan". This determines whether a given feature is supported
       by the vSwitch in the underlying distribution, and therefore can be enabled in the

--- a/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
+++ b/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
@@ -75,7 +75,7 @@ parameters:
       interface should be a OVS interface.
   ACIOpflexDisabledFeatures:
     type: comma_delimited_list
-    default: "erspan"
+    default: ""
     description: >
       Valid values are "erspan". This determines whether a given feature is supported
       by the vSwitch in the underlying distribution, and therefore can be enabled in the

--- a/tripleo-ciscoaci/deployment/neutron_compute/ciscoaci_compute.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_compute/ciscoaci_compute.yaml
@@ -54,7 +54,7 @@ parameters:
       interface should be a OVS interface.
   ACIOpflexDisabledFeatures:
     type: comma_delimited_list
-    default: "erspan"
+    default: ""
     description: >
       Valid values are "erspan". This determines whether a given feature is supported
       by the vSwitch in the underlying distribution, and therefore can be enabled in the

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -84,7 +84,7 @@ parameters:
     default: 'aci_openstack'
   ACIOpflexDisabledFeatures:
     type: comma_delimited_list
-    default: "erspan"
+    default: ""
     description: >
       Valid values are "erspan". This determines whether a given feature is supported
       by the vSwitch in the underlying distribution, and therefore can be enabled in the


### PR DESCRIPTION
Remove "erspan" from the list of disabled features in the
the opflex agent.