### PR TITLE
Added cleanup of /var/lib/image-serve/v2/__acirepo/

### DIFF
--- a/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
+++ b/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
@@ -227,6 +227,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 """ 
+       os.system("sudo rm -rf /var/lib/image-serve/v2/__acirepo")
        os.system("sudo mkdir -p /var/lib/image-serve/v2/__acirepo")
        os.system("cp /opt/cisco_aci_repo/ciscoaci-puppet-* /var/lib/image-serve/v2/__acirepo")
        os.system("createrepo /var/lib/image-serve/v2/__acirepo")


### PR DESCRIPTION
Temp pupper repi /var/lib/image-serve/v2/__acirepo/ was not getting cleared
resulting in multiple packages and causing wrong version of puppet classes.