### PR TITLE
To create new container for neutron-opflex-agent

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
@@ -1,0 +1,241 @@
+heat_template_version: queens
+
+description: >
+  OpenStack Cisco Aci neutron opflex service
+
+parameters:
+  DockerNeutronOpflexAgentImage:
+    description: image
+    type: string
+  DockerNeutronConfigImage:
+    description: The container image to use for the neutron config_volume
+    type: string
+  DockerOpenvswitchUlimit:
+    default: ['nofile=1024']
+    description: ulimit for Openvswitch Container
+    type: comma_delimited_list
+  ServiceData:
+    default: {}
+    description: Dictionary packing service data
+    type: json
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+  RoleName:
+    default: ''
+    description: Role name on which the service is applied
+    type: string
+  RoleParameters:
+    default: {}
+    description: Parameters specific to the role
+    type: json
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  UpgradeRemoveUnusedPackages:
+    default: false
+    description: Remove package if the service is being disabled during upgrade
+    type: boolean
+
+resources:
+
+  ContainersCommon:
+    type: /usr/share/openstack-tripleo-heat-templates/docker/services/containers-common.yaml
+
+  NeutronOpflexAgentBase:
+    type:  /opt/ciscoaci-tripleo-heat-templates/puppet/services/neutron-opflex-agent.yaml
+    properties:
+      EndpointMap: {get_param: EndpointMap}
+      ServiceData: {get_param: ServiceData}
+      ServiceNetMap: {get_param: ServiceNetMap}
+      DefaultPasswords: {get_param: DefaultPasswords}
+      RoleName: {get_param: RoleName}
+      RoleParameters: {get_param: RoleParameters}
+
+outputs:
+  role_data:
+    description: Role data for Neutron openvswitch service
+    value:
+      service_name: {get_attr: [NeutronOpflexAgentBase, role_data, service_name]}
+      config_settings:
+        map_merge:
+          - get_attr: [NeutronOpflexAgentBase, role_data, config_settings]
+      logging_source: {get_attr: [NeutronOpflexAgentBase, role_data, logging_source]}
+      logging_groups: {get_attr: [NeutronOpflexAgentBase, role_data, logging_groups]}
+      service_config_settings: {get_attr: [NeutronOpflexAgentBase, role_data, service_config_settings]}
+      puppet_config:
+        config_volume: neutron_opflex
+        puppet_tags:  
+        step_config:
+          get_attr: [NeutronOpflexAgentBase, role_data, step_config]
+        config_image: {get_param: DockerNeutronOpflexAgentImage}
+        # We need to mount /run for puppet_config step. This is because
+        # puppet-vswitch runs the commands "ovs-vsctl list open_vswitch ."
+        # when running vswitch::ovs::enable_hw_offload: true
+        # ovs-vsctl talks to the ovsdb-server (hosting conf.db)
+        # on the unix domain socket - /run/openvswitch/db.sock
+        volumes:
+          - /lib/modules:/lib/modules:ro
+          - /run/openvswitch:/run/openvswitch
+          - /usr/bin:/usr/bin
+          - /usr/lib/python2.7:/usr/lib/python2.7
+          - /sys/class/net:/sys/class/net
+          - /sys/devices:/sys/devices
+      kolla_config:
+        /var/lib/kolla/config_files/ciscoaci_neutron_opflex_agent.json:
+          command: /bin/supervisord -c /etc/neutron/neutron_opflex_supervisord.conf
+          config_files:
+            - source: "/var/lib/kolla/config_files/src/*"
+              dest: "/"
+              merge: true
+              preserve_properties: true
+          permissions:
+            - path: /var/log/neutron
+              owner: neutron:neutron
+              recurse: true
+            - path: /var/lib/neutron
+              owner: neutron:neutron
+              recurse: true
+      docker_config_scripts: {get_attr: [ContainersCommon, docker_config_scripts]}
+      docker_config:
+        step_4:
+          ciscoaci_neutron_opflex_agent:
+            start_order: 14
+            image: {get_param: DockerNeutronOpflexAgentImage}
+            net: host
+            pid: host
+            privileged: true
+            restart: always
+            healthcheck:
+              test: /etc/neutron/neutron_opflex_healthcheck
+            volumes:
+              list_concat:
+                - {get_attr: [ContainersCommon, volumes]}
+                -
+                  - /var/lib/kolla/config_files/ciscoaci_neutron_opflex_agent.json:/var/lib/kolla/config_files/config.json:ro
+                  - /lib/modules:/lib/modules:ro
+                  - /run/openvswitch:/run/openvswitch
+                  - /var/lib/config-data/puppet-generated/neutron_opflex/:/var/lib/kolla/config_files/src:ro
+                  - /var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf:/etc/neutron/neutron.conf:ro
+                  - /var/lib/config-data/puppet-generated/neutron/etc/neutron/metadata_agent.ini:/etc/neutron/metadata_agent.ini:ro
+                  - /var/lib/neutron:/var/lib/neutron
+                  - /var/log/containers/neutron:/var/log/neutron
+                  - /lib/modules:/lib/modules:ro
+                  - opflex_endpoints:/var/lib/opflex-agent-ovs
+                  - opflex_socket:/run/opflex
+            environment:
+              - KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
+      metadata_settings:
+        get_attr: [NeutronOpflexAgentBase, role_data, metadata_settings]
+      host_prep_tasks: []
+      upgrade_tasks:
+        list_concat:
+          - get_attr: [NeutronOpflexAgentBase, role_data, ovs_upgrade_tasks]
+          -
+            - name: Check if neutron_opflex_agent is deployed
+              command: systemctl is-enabled --quiet neutron-opflex-agent
+              tags: common
+              ignore_errors: True
+              register: neutron_opflex_agent_enabled
+            - name: "PreUpgrade step0,validation: Check service neutron-opflex-agent is running"
+              command: systemctl is-active --quiet neutron-opflex-agent
+              when:
+                - step|int == 0
+                - neutron_opflex_agent_enabled.rc == 0
+              tags: validation
+            - name: Stop and disable neutron_opflex_agent service
+              when:
+                - step|int == 2
+                - neutron_opflex_agent_enabled.rc == 0
+              service: name=neutron-opflex-agent state=stopped enabled=no
+
+            - name: Set fact for removal of neutron-opflex-agent package
+              when: step|int == 2
+              set_fact:
+                remove_neutron_opflex_package: {get_param: UpgradeRemoveUnusedPackages}
+            - name: Remove neutron-opflex-agent package if operator requests it
+              yum: name=neutron-opflex-agent state=removed
+              ignore_errors: True
+              when:
+                - step|int == 2
+                - remove_neutron_opflex_package|bool
+
+      update_tasks:
+      fast_forward_upgrade_tasks:
+        - name: Remove neutron-ml2-driver-apic package
+          yum: name=neutron-ml2-driver-apic state=removed
+          ignore_errors: True
+          when:
+            - step|int == 0
+            - release == 'ocata'
+        - name: Check if neutron_opflex_agent is deployed
+          command: systemctl is-enabled --quiet neutron-opflex-agent
+          ignore_errors: True
+          register: neutron_opflex_agent_enabled_result
+          when:
+            - step|int == 0
+            - release == 'ocata'
+        - name: Set fact neutron_opflex_agent_enabled
+          set_fact:
+            neutron_opflex_agent_enabled: "{{ neutron_opflex_agent_enabled_result.rc == 0 }}"
+          when:
+            - step|int == 0
+            - release == 'ocata'
+        - name: Stop neutron_opflex_agent
+          service: name=neutron-opflex-agent state=stopped enabled=no
+          when:
+            - step|int == 1
+            - release == 'ocata'
+            - neutron_opflex_agent_enabled|bool
+        - name: Check if neutron_opflex_agent is deployed
+          command: systemctl is-enabled --quiet neutron-opflex-agent
+          ignore_errors: True
+          register: neutron_opflex_agent_enabled_result
+          when:
+            - step|int == 0
+            - release == 'ocata'
+        - name: Set fact neutron_opflex_agent_enabled
+          set_fact:
+            neutron_opflex_agent_enabled: "{{ neutron_opflex_agent_enabled_result.rc == 0 }}"
+          when:
+            - step|int == 0
+            - release == 'ocata'
+        - name: Stop neutron_opflex_agent
+          service: name=neutron-opflex-agent state=stopped enabled=no
+          when:
+            - step|int == 1
+            - release == 'ocata'
+            - neutron_opflex_agent_enabled|bool
+        - name: stop metadata agent
+          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop metadata-agent
+          ignore_errors: True
+          when:
+            - step|int == 1
+            - release == 'ocata'
+            - neutron_opflex_agent_enabled|bool
+        - name: stop opflex state watcher
+          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop opflex-state-watcher
+          ignore_errors: True
+          when:
+            - step|int == 1
+            - release == 'ocata'
+            - neutron_opflex_agent_enabled|bool
+        - name: stop opflex ep watcher
+          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop opflex-ep-watcher
+          ignore_errors: True
+          when:
+            - step|int == 1
+            - release == 'ocata'
+            - neutron_opflex_agent_enabled|bool
+        - name: neutron opflex agent package update
+          shell: yum -y update neutron-opflex-agent
+          when:
+            - step|int == 6

--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -133,11 +133,13 @@ outputs:
                   - /run/netns:/run/netns:shared
                   - /run/openvswitch:/run/openvswitch
                   - /lib/modules:/lib/modules:ro
+                  - opflex_endpoints:/var/lib/opflex-agent-ovs
+                  - opflex_socket:/run/opflex
             environment:
               - KOLLA_CONFIG_STRATEGY=COPY_ALWAYS
       metadata_settings:
         get_attr: [OpflexAgentBase, role_data, metadata_settings]
-      host_prep_tasks: 
+      host_prep_tasks:
             - name: create /run/netns with temp namespace
               command: ip netns add ns_temp
               register: ipnetns_add_result
@@ -411,35 +413,6 @@ outputs:
               when:
                 - step|int == 2
                 - remove_agent_ovs_package|bool
-
-            - name: Check if neutron_opflex_agent is deployed
-              command: systemctl is-enabled --quiet neutron-opflex-agent
-              tags: common
-              ignore_errors: True
-              register: neutron_opflex_agent_enabled
-            - name: "PreUpgrade step0,validation: Check service neutron-opflex-agent is running"
-              command: systemctl is-active --quiet neutron-opflex-agent
-              when:
-                - step|int == 0
-                - neutron_opflex_agent_enabled.rc == 0
-              tags: validation
-            - name: Stop and disable neutron_opflex_agent service
-              when:
-                - step|int == 2
-                - neutron_opflex_agent_enabled.rc == 0
-              service: name=neutron-opflex-agent state=stopped enabled=no
-
-            - name: Set fact for removal of neutron-opflex-agent package
-              when: step|int == 2
-              set_fact:
-                remove_neutron_opflex_package: {get_param: UpgradeRemoveUnusedPackages}
-            - name: Remove neutron-opflex-agent package if operator requests it
-              yum: name=neutron-opflex-agent state=removed
-              ignore_errors: True
-              when:
-                - step|int == 2
-                - remove_neutron_opflex_package|bool
-
             - name: get infra vlan
               command: hiera -c /etc/puppet/hiera.yaml ciscoaci::opflex::aci_apic_infravlan
               register: vlanout
@@ -547,26 +520,6 @@ outputs:
           when:
             - step|int == 0
             - release == 'ocata'
-        - name: Check if neutron_opflex_agent is deployed
-          command: systemctl is-enabled --quiet neutron-opflex-agent
-          ignore_errors: True
-          register: neutron_opflex_agent_enabled_result
-          when:
-            - step|int == 0
-            - release == 'ocata'
-        - name: Set fact neutron_opflex_agent_enabled
-          set_fact:
-            neutron_opflex_agent_enabled: "{{ neutron_opflex_agent_enabled_result.rc == 0 }}"
-          when:
-            - step|int == 0
-            - release == 'ocata'
-        - name: Stop neutron_opflex_agent
-          service: name=neutron-opflex-agent state=stopped enabled=no
-          when:
-            - step|int == 1
-            - release == 'ocata'
-            - neutron_opflex_agent_enabled|bool
-
         - name: Check if agent_ovs is deployed
           command: systemctl is-enabled --quiet agent-ovs
           ignore_errors: True
@@ -626,51 +579,7 @@ outputs:
             - step|int == 1
             - release == 'ocata'
             - mcast_daemon_enabled|bool
-        - name: Check if neutron_opflex_agent is deployed
-          command: systemctl is-enabled --quiet neutron-opflex-agent
-          ignore_errors: True
-          register: neutron_opflex_agent_enabled_result
-          when:
-            - step|int == 0
-            - release == 'ocata'
-        - name: Set fact neutron_opflex_agent_enabled
-          set_fact:
-            neutron_opflex_agent_enabled: "{{ neutron_opflex_agent_enabled_result.rc == 0 }}"
-          when:
-            - step|int == 0
-            - release == 'ocata'
-        - name: Stop neutron_opflex_agent
-          service: name=neutron-opflex-agent state=stopped enabled=no
-          when:
-            - step|int == 1
-            - release == 'ocata'
-            - neutron_opflex_agent_enabled|bool
-        - name: stop metadata agent
-          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop metadata-agent
-          ignore_errors: True
-          when:
-            - step|int == 1
-            - release == 'ocata'
-            - neutron_opflex_agent_enabled|bool
-        - name: stop opflex state watcher
-          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop opflex-state-watcher
-          ignore_errors: True
-          when:
-            - step|int == 1
-            - release == 'ocata'
-            - neutron_opflex_agent_enabled|bool
-        - name: stop opflex ep watcher
-          command: supervisorctl -c /var/lib/neutron/opflex_agent/metadata.conf stop opflex-ep-watcher
-          ignore_errors: True
-          when:
-            - step|int == 1
-            - release == 'ocata'
-            - neutron_opflex_agent_enabled|bool
         - name: agent ovs package update
           shell: yum -y update agent-ovs
-          when:
-            - step|int == 6
-        - name: neutron opflex agent package update
-          shell: yum -y update neutron-opflex-agent
           when:
             - step|int == 6

--- a/tripleo-ciscoaci/puppet/services/neutron-opflex-agent.yaml
+++ b/tripleo-ciscoaci/puppet/services/neutron-opflex-agent.yaml
@@ -1,0 +1,127 @@
+heat_template_version: queens
+
+description: >
+  OpenStack Neutron Opflex agent 
+
+parameters:
+  ServiceData:
+    default: {}
+    description: Dictionary packing service data
+    type: json
+  ServiceNetMap:
+    default: {}
+    description: Mapping of service_name -> network name. Typically set
+                 via parameter_defaults in the resource registry.  This
+                 mapping overrides those in ServiceNetMapDefaults.
+    type: json
+  DefaultPasswords:
+    default: {}
+    type: json
+  RoleName:
+    default: ''
+    description: Role name on which the service is applied
+    type: string
+  RoleParameters:
+    default: {}
+    description: Parameters specific to the role
+    type: json
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol. Typically set
+                 via parameter_defaults in the resource registry.
+    type: json
+  NeutronBridgeMappings:
+    description: >
+      The OVS logical->physical bridge mappings to use. See the Neutron
+      documentation for details. Defaults to mapping br-ex - the external
+      bridge on hosts - to a physical name 'datacentre' which can be used
+      to create provider networks (and we use this for the default floating
+      network) - if changing this either use different post-install network
+      scripts or be sure to keep 'datacentre' as a mapping network name.
+    type: comma_delimited_list
+    default: "datacentre:br-ex"
+  NeutronOVSFirewallDriver:
+    default: 'neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver'
+    description: |
+      Configure the classname of the firewall driver to use for implementing
+      security groups. Possible values depend on system configuration. Some
+      examples are: noop, openvswitch, iptables_hybrid. The default value of an
+      empty string will result in a default supported configuration.
+    type: string
+
+resources:
+
+  NeutronBase:
+    type: /usr/share/openstack-tripleo-heat-templates/puppet/services/neutron-base.yaml
+    properties:
+      ServiceData: {get_param: ServiceData}
+      ServiceNetMap: {get_param: ServiceNetMap}
+      DefaultPasswords: {get_param: DefaultPasswords}
+      EndpointMap: {get_param: EndpointMap}
+      RoleName: {get_param: RoleName}
+      RoleParameters: {get_param: RoleParameters}
+
+  Ovs:
+    type: /usr/share/openstack-tripleo-heat-templates/puppet/services/openvswitch.yaml
+    properties:
+      ServiceNetMap: {get_param: ServiceNetMap}
+      DefaultPasswords: {get_param: DefaultPasswords}
+      EndpointMap: {get_param: EndpointMap}
+
+  # Merging role-specific parameters (RoleParameters) with the default parameters.
+  # RoleParameters will have the precedence over the default parameters.
+  RoleParametersValue:
+    type: OS::Heat::Value
+    properties:
+      type: json
+      value:
+        map_replace:
+          - map_replace:
+            - neutron::agents::ml2::ovs::bridge_mappings: NeutronBridgeMappings
+              #vswitch::ovs::enable_hw_offload: OvsHwOffload
+            - values: {get_param: [RoleParameters]}
+          - values:
+              NeutronBridgeMappings: {get_param: NeutronBridgeMappings}
+              #OvsHwOffload: {get_param: OvsHwOffload}
+
+outputs:
+  role_data:
+    description: Role data for the Neutron OVS agent service.
+    value:
+      service_name: neutron_opflex_agent
+      ovs_upgrade_tasks: {get_attr: [Ovs, role_data, upgrade_tasks]}
+      config_settings:
+        map_merge:
+          - get_attr: [NeutronBase, role_data, config_settings]
+          - get_attr: [RoleParametersValue, value]
+          - neutron::agents::ml2::ovs::local_ip: {get_param: [ServiceNetMap, NeutronTenantNetwork]}
+            tripleo.opflex_agent.firewall_rules:
+              '297 opflex vxlan networks':
+                proto: 'udp'
+                dport: 8472
+              '298 opflex igmp accept':
+                proto: 'igmp'
+      step_config: |
+        include ::tripleo::profile::base::ciscoaci_neutron_opflex
+      upgrade_tasks:
+        list_concat:
+          - get_attr: [Ovs, role_data, upgrade_tasks]
+          -
+            - name: Check if neutron_ovs_agent is deployed
+              command: systemctl is-enabled neutron-openvswitch-agent
+              tags: common
+              ignore_errors: True
+              register: neutron_ovs_agent_enabled
+            - name: "PreUpgrade step0,validation: Check service neutron-openvswitch-agent is running"
+              shell: /usr/bin/systemctl show 'neutron-openvswitch-agent' --property ActiveState | grep '\bactive\b'
+              when:
+                - step|int == 0
+                - neutron_ovs_agent_enabled.rc == 0
+              tags: validation
+            - name: Stop neutron_ovs_agent service
+              when:
+                - step|int == 1
+                - neutron_ovs_agent_enabled.rc == 0
+              service: name=neutron-openvswitch-agent state=stopped
+      metadata_settings:
+        get_attr: [NeutronBase, role_data, metadata_settings]

--- a/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
+++ b/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
@@ -245,6 +245,14 @@ gpgcheck=0
             "osd_param_name": ["DockerOpflexAgentImage"],
             "user": 'root',
         },
+        'neutron-opflex-agent': {
+            "rhel_container": "openstack-neutron-openvswitch-agent",
+            "aci_container": "openstack-ciscoaci-neutron-opflex",
+            "packages": [],
+            "run_cmds": ["yum -y install ciscoaci-puppet ethtool neutron-opflex-agent apicapi openstack-neutron-gbp python2-networking-sfc"],
+            "osd_param_name": ["DockerNeutronOpflexAgentImage"],
+            "user": 'root',
+        },
     }
 
     if options.containers_tb == 'all':

--- a/tripleo-ciscoaci/tools/report_vars.yaml
+++ b/tripleo-ciscoaci/tools/report_vars.yaml
@@ -19,6 +19,9 @@
       opflex:
         rpath: /var/lib/config-data/opflex/
         lpath: opflex/config-data
+      neutron_opflex:
+        rpath: /var/lib/config-data/neutron_opflex/
+        lpath: neutron_opflex/config-data
       opflex_state:
         rpath: /tmp/opflex-agent-ovs
         lpath: opflex
@@ -28,6 +31,9 @@
       puppet_opflex:
         rpath: /var/lib/config-data/puppet-generated/opflex/
         lpath: opflex/config-data/puppet-generated
+      puppet_neutron_opflex:
+        rpath: /var/lib/config-data/puppet-generated/neutron_opflex/
+        lpath: neutron_opflex/config-data/puppet-generated  
       hiera:
         rpath: /etc/puppet/hieradata
         lpath: hieradata


### PR DESCRIPTION
Unit testing done:
Steps to test notification socket between opflex-agent and neutron-opflex-agent:

create 2 servers in same  dhcp network.
assign address_pair on both of them with a vip and same mac.
verify that vip is present in ep file
verify ping works between the two instances
add vip as an subinterfcae eth0:0 in both instances
initiate garp from S1: and S1 becomes owner of the vip, and verify vip in the list of ips in the ep file of S1
initiate garp from S2 and S2 becomes owner oof the vip and verify vip in the list of ips in the ep file of S2

Ep files testing: 
(nosh: neutron-opflex-agent container) (new container)
(osh: opflex-agent container) (old container)
                         
--> Assigned qos1 to port, verified qos info is written to ep file, and then to ovs-db.
--> Changed qos2 to port, verified qos2 is wrotten to ep file, and then to ovs-db.

--> Powered off nosh, verified ep-files are intact. 
--> Powered on nosh,.

-->Powered off osh, verified ep-files are intact, and qos config is present in ovs-db. 
-->Powered on osh

--> Powered off osh, changed qos config, verified change in ep file, verified stale config in ovs-db.
-->Powered on osh, verified new qos config in ovs-db.

--> Powered off nosh, changed qos config, verified stale qos in ep file and ovs-db.
--> Powered on nosh , verified updated qos config  in ep file and in ovsdb.

-->Powered off both , verified intact ep files and ovsdb config.
-->Powered on both.
