### PR TITLE
Reemove uses of root user

### DIFF
--- a/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
@@ -333,7 +333,7 @@ outputs:
               preserve_properties: true
           permissions:
             - path: /var/log/aim
-              owner: root:root
+              owner: neutron:neutron
               recurse: true
       container_config_scripts: {get_attr: [ContainersCommon, container_config_scripts]}
       docker_config:
@@ -362,7 +362,7 @@ outputs:
             net: host
             privileged: false
             detach: false
-            user: root
+            user: neutron
             volumes:
               list_concat:
                 - {get_attr: [ContainersCommon, volumes]}


### PR DESCRIPTION
There are still places where root is used for our services. These
should be changed to neutron.