### PR TITLE
Fix permissions

### DIFF
--- a/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
@@ -340,7 +340,10 @@ outputs:
               preserve_properties: true
           permissions:
             - path: /var/log/aim
-              owner: root:root
+              owner: neutron:neutron
+              recurse: true
+            - path: /run/aid
+              owner: neutron:neutron
               recurse: true
       container_config_scripts: {get_attr: [ContainersCommon, container_config_scripts]}
       docker_config:
@@ -421,6 +424,7 @@ outputs:
             restart: always
             healthcheck:
               test: /etc/aim/aim_healthcheck
+            user: neutron
             volumes:
               list_concat:
                 - {get_attr: [ContainersCommon, volumes]}
@@ -451,7 +455,7 @@ outputs:
         #    environment:
         #      KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
       host_prep_tasks: 
-        - name: create persistent logs directory for cisco aci aim
+        - name: create persistent directories
           file:
             path: /var/log/containers/aim
             state: directory

--- a/tripleo-ciscoaci/deployment/lldp/cisco_lldp.yaml
+++ b/tripleo-ciscoaci/deployment/lldp/cisco_lldp.yaml
@@ -75,6 +75,7 @@ outputs:
             image: {get_param: ContainerCiscoLldpImage}
             net: host
             pid: host
+            user: root
             privileged: true
             restart: always
             healthcheck:
@@ -91,7 +92,7 @@ outputs:
               KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
       metadata_settings:
       host_prep_tasks: 
-            - name: create persistent logs directory for cisco opflex agent
+            - name: create persistent directories
               file:
                 path: /var/log/containers/neutron
                 state: directory

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -207,7 +207,7 @@ outputs:
         # on the unix domain socket - /run/openvswitch/db.sock
         volumes:
           - /lib/modules:/lib/modules:ro
-          - /run/openvswitch:/run/openvswitch
+          - /run/openvswitch:/run/openvswitch:shared,z
           - /etc/os-net-config:/etc/os-net-config:ro
       kolla_config:
         /var/lib/kolla/config_files/ciscoaci_opflex_agent.json:
@@ -221,6 +221,12 @@ outputs:
             - path: /var/log/neutron
               owner: neutron:neutron
               recurse: true
+            - path: /var/log/opflex
+              owner: neutron:neutron
+              recurse: true
+            - path: /run
+              owner: neutron:neutron
+              recurse: false
       docker_config_scripts: {get_attr: [ContainersCommon, container_config_scripts]}
       docker_config:
         step_4:
@@ -229,6 +235,7 @@ outputs:
             image: {get_param: ContainerOpflexAgentImage}
             net: host
             pid: host
+            user: root
             privileged: true
             restart: always
             healthcheck:
@@ -238,13 +245,12 @@ outputs:
                 - {get_attr: [ContainersCommon, volumes]}
                 -
                   - /var/lib/kolla/config_files/ciscoaci_opflex_agent.json:/var/lib/kolla/config_files/config.json:ro
-                  - /run/openvswitch:/run/openvswitch
+                  - /run/openvswitch:/run/openvswitch:shared,z
                   - /var/lib/config-data/puppet-generated/opflex/:/var/lib/kolla/config_files/src:ro
                   - /var/lib/config-data/puppet-generated/neutron/etc/neutron/neutron.conf:/etc/neutron/neutron.conf:ro
                   - /var/lib/config-data/puppet-generated/neutron/etc/neutron/metadata_agent.ini:/etc/neutron/metadata_agent.ini:ro
                   - /var/log/containers/opflex:/var/log/opflex
                   - /var/log/containers/neutron:/var/log/neutron
-                  - /var/run/openvswitch/:/var/run/openvswitch/
                   - /run/netns:/run/netns:shared
                   - /lib/modules:/lib/modules:ro
             environment:
@@ -262,6 +268,9 @@ outputs:
             - name: create persistent logs directory for cisco opflex agent
               file:
                 path: /var/log/containers/opflex
+                state: directory
+                setype: svirt_sandbox_file_t
+                mode: '0750'
                 state: directory
 
             - name: get opflex interface type


### PR DESCRIPTION
Put pieces in place to allow for running containers in non-root
mode. We still need parts of it for now, until we can address
the LLDP and opflex-agent use cases.