### PR TITLE
Revert "Add plugin.ini to GBP DB migration"

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_aciaim.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_aciaim.yaml
@@ -135,7 +135,7 @@ outputs:
                   - /var/lib/config-data/aim/etc/aim:/etc/aim:ro
                   - /var/lib/config-data/neutron/etc/neutron:/etc/neutron:ro
             command: ['/usr/bin/bootstrap_host_exec', 'neutron_plugin_ciscoaci', 
-                      '/bin/gbp-db-manage', '--config-file', '/etc/neutron/neutron.conf', '--config-file', '/etc/neutron/plugin.ini', 'upgrade', 'head', '&&',
+                      '/bin/gbp-db-manage', '--config-file', '/etc/neutron/neutron.conf', 'upgrade', 'head', '&&',
                       '/usr/bin/aimctl', 'db-migration', 'upgrade', 'head', '&&', 
                       '/usr/bin/aimctl', 'config', 'update', '&&', 
                       '/usr/bin/aimctl', 'infra', 'create', '&&', 
@@ -319,7 +319,7 @@ outputs:
           when:
             - step|int == 6
         - name: gbp db upgrade
-          command: /bin/gbp-db-manage --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/plugin.ini upgrade head
+          command: /bin/gbp-db-manage --config-file /etc/neutron/neutron.conf upgrade head
           when:
             - step|int == 8
             - is_bootstrap_node|bool


### PR DESCRIPTION
This reverts commit 30428738f76945bf422b242e602d51cc4a538dc3. The
patch was created to support a change in the GBP plugin, which has
since been reverted.