### PR TITLE
Fix OSP10 => OSP13 FFU

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -543,6 +543,15 @@ outputs:
           service: name=opflex-agent state=stopped enabled=no
           when:
             - opflex_agent_enabled|bool
+        # We have to restart the containerized version, because the supervisord
+        # stopped it due to excessive crashes (couldn't access resources that were
+        # shared by the opfle-agent that had been running on the hypervisor).
+        - name: Restart containerized opflex_agent
+          command: docker restart ciscoaci_opflex_agent
+          become: True
+          ignore_errors: True
+          when:
+            - opflex_agent_enabled|bool
 
         # As part of an FFU from OSP10, the previous ML2 configuration
         # file gets deleted, but also backed up as an rpmsave file. This


### PR DESCRIPTION
During fast-forward upgrades (FFUs), there is a transition from
using the systemd opflex-agent running on the hypervisor, and the
containerized opflex-agent. We start the opflex-agent while we still
have the systemd opflex-agent running. This causes the containerized
opflex-agent to crash, as it's trying to access some of the same
resources (e.g. sockets) as the systemd one, which causes supervisord
in the container to stop the opflex-agent process.

This patch does a restart of the opflex-agent container after bringing
down the systemd opflex-agent, so that the containerized one can then
come back up cleanly.