### PR TITLE
Fix host report with split containers

### DIFF
--- a/tripleo-ciscoaci/tools/report.yml
+++ b/tripleo-ciscoaci/tools/report.yml
@@ -143,6 +143,7 @@
         - system
         - ovs
         - neutron/config-data/puppet-generated
+        - neutron_opflex/config-data/puppet-generated
         - nova/config-data/puppet-generated
         - opflex/config-data/puppet-generated
         - containers/config-data/puppet-generated
@@ -167,10 +168,6 @@
       delegate_to: localhost
       no_log: True
 
-    - name: docker copy
-      shell: "docker cp ciscoaci_opflex_agent:/var/lib/opflex-agent-ovs /tmp"
-      become: true
-   
     - name: exec commands
       shell: "{{ item.value.cmd }}"
       register: ctrl_output

--- a/tripleo-ciscoaci/tools/report_vars.yaml
+++ b/tripleo-ciscoaci/tools/report_vars.yaml
@@ -23,7 +23,7 @@
         rpath: /var/lib/config-data/neutron_opflex/
         lpath: neutron_opflex/config-data
       opflex_state:
-        rpath: /tmp/opflex-agent-ovs
+        rpath: /var/lib/opflex/files
         lpath: opflex
       puppet_neutron:
         rpath: /var/lib/config-data/puppet-generated/neutron/


### PR DESCRIPTION
After splitting the containers, the opflex files are now available
directly on the hypervisor's file system.