### PR TITLE
Fix OSP10 to OSP13 FFU

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -297,7 +297,7 @@ outputs:
 
             - name: bring up infra interface
               command: "/sbin/ifup {{ aci_opflex_uplink_interface }}.{{ aci_apic_infravlan }}"
-              when: infra_dhcp_file is changed or infra_interface is changed
+              ignore_errors: True
 
             - name: setup br-fabric bridge
               command: "/bin/ovs-vsctl -- --may-exist add-br br-fabric"
@@ -523,7 +523,9 @@ outputs:
 
             - name: bring up infra interface
               command: "/sbin/ifup {{ aci_opflex_uplink_interface }}.{{ aci_apic_infravlan }}"
-              when: step|int == 2 and (infra_dhcp_file is changed or infra_interface is changed)
+              ignore_errors: True
+              when:
+                - step|int == 2
 
       post_upgrade_tasks:
         # This was moved to post_upgrade_tasks in order to ensure that


### PR DESCRIPTION
When doing an OSP10 to OSP13 Fast-Forward Upgrade (FFU), the
steps remove the old "vlan<vlan ID" interface at the beginning
of an upgrade_task. The interface isn't restored until much later.
This fixes that, by ensuring that the ifup on the new interface
that replaces it happens earller on in the process, minimizing
down time.