### PR TITLE
Fix greenfield deployments

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -108,7 +108,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_opflex_agent:
-            start_order: 14
+            start_order: 18
             image: {get_param: DockerOpflexAgentImage}
             net: host
             pid: host


### PR DESCRIPTION
The opflex-agent needs to be started after the neutron-opflex-agent,
so that there's not a conflict with flow-programming (the neutron-
opflex-agent creates a canary flow, as part of the upstream code,
whenever an OVS bridge is created).