### PR TITLE
Fix roles data scripts

### DIFF
--- a/tripleo-ciscoaci/tools/generate_ciscoaci_role_data.sh
+++ b/tripleo-ciscoaci/tools/generate_ciscoaci_role_data.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-cat /usr/share/openstack-tripleo-heat-templates/roles_data.yaml | awk '{print} /- OS::TripleO::Services::NeutronOvsAgent/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciAIM" }' | awk '{print} /- OS::TripleO::Services::CiscoAciAIM/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciLldp" }' | awk '{print} /- OS::TripleO::Services::ComputeNeutronOvsAgent/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciLldp" }'
+cat /usr/share/openstack-tripleo-heat-templates/roles_data.yaml \
+    | awk '{print} /- OS::TripleO::Services::NeutronOvsAgent/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciAIM" }' \
+    | awk '{print} /- OS::TripleO::Services::CiscoAciAIM/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciLldp" }' \
+    | awk '{print} /- OS::TripleO::Services::CiscoAciAIM/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciOpflexAgent" }' \
+    | awk '{print} /- OS::TripleO::Services::ComputeNeutronOvsAgent/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciLldp" }' \
+    | awk '{print} /- OS::TripleO::Services::ComputeNeutronOvsAgent/{ print substr($0,1,match($0,/[^[:space:]]/)-1) "- OS::TripleO::Services::CiscoAciOpflexAgent" }'

--- a/tripleo-ciscoaci/tools/generate_ciscoaci_role_data.yaml
+++ b/tripleo-ciscoaci/tools/generate_ciscoaci_role_data.yaml
@@ -1,0 +1,21 @@
+---
+- name: Add cisco-specific composable services to custom roles file
+  hosts: undercloud
+  vars:
+    custom_roles_file: /home/stack/templates/custom_roles_data.yaml
+  tasks:
+  - name: Copy /usr/share/openstack-tripleo-heat-templates/roles_data.yaml to templates directory
+    command: cp /usr/share/openstack-tripleo-heat-templates/roles_data.yaml "{{ custom_roles_file }}"
+  - name: Add the agent composable services to Controller and Compute roles
+    replace:
+      path: "{{ custom_roles_file }}"
+      regexp: 'NeutronOvsAgent\n(?!{{repl_str}})'
+      replace: 'NeutronOvsAgent\n{{repl_str}}'
+    vars:
+      repl_str: '    - OS::TripleO::Services::CiscoAciOpflexAgent\n    - OS::TripleO::Services::CiscoAciLldp\n'
+  - name: Add the AIM composable services to the Controller role
+    lineinfile:
+      path: "{{ custom_roles_file }}"
+      insertbefore: '    - OS::TripleO::Services::CiscoAciOpflexAgent'
+      firstmatch: yes
+      line: '    - OS::TripleO::Services::CiscoAciAIM'


### PR DESCRIPTION
This fixes the scripts that add the Cisco-specific services to the
custom roles data yaml file. The existing shell script is modified to
add the new opflex-agent service, and an ansible playbook is added that
does the same, giving users two options for creating the custom roles
data file.