### PR TITLE
Change opflex-agent start order

### DIFF
--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -163,7 +163,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_opflex_agent:
-            start_order: 14
+            start_order: 18
             image: {get_param: ContainerOpflexAgentImage}
             net: host
             pid: host


### PR DESCRIPTION
The opflex-agent should be started after the neutron-opflex-agent,
so bump the start order.