### PR TITLE
Change container start order for deployment

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
@@ -108,7 +108,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_neutron_opflex_agent:
-            start_order: 14
+            start_order: 18
             image: {get_param: DockerNeutronOpflexAgentImage}
             net: host
             pid: host

--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -108,7 +108,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_opflex_agent:
-            start_order: 18
+            start_order: 14
             image: {get_param: DockerOpflexAgentImage}
             net: host
             pid: host


### PR DESCRIPTION
During deployment (initial or upgrade), we want to start the
neutron-opflex-agent container after the opflex-agent container.
Commit 338e2eb72db3d160d189e98f86f2fc7e6b49d4f1 to the puppet
repo queens branch (https://github.com/noironetworks/ciscoaci-puppet)
ensures that the opflex-agent container is restarted when the
neutron-opflex-agent container is (re-)started, so that the
two agents don't conflict with the vSwitch, and flow-mods get
programmed correctly.