### PR TITLE
Change container start order for deployment

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
@@ -145,7 +145,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_neutron_opflex_agent:
-            start_order: 14
+            start_order: 18
             image: {get_param: ContainerNeutronOpflexAgentImage}
             net: host
             pid: host

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -163,7 +163,7 @@ outputs:
       docker_config:
         step_4:
           ciscoaci_opflex_agent:
-            start_order: 18
+            start_order: 14
             image: {get_param: ContainerOpflexAgentImage}
             net: host
             pid: host


### PR DESCRIPTION
During deployment (initial or upgrade), we want to start the
neutron-opflex-agent container after the opflex-agent container.
Commit 3392a1f52a02ddea3c57c4ffb7c63b5182d5aaed to the puppet
repo train branch (https://github.com/noironetworks/ciscoaci-puppet)
ensures that the opflex-agent container is restarted when the
neutron-opflex-agent container is (re-)started, so that the
two agents don't conflict with the vSwitch, and flow-mods get
programmed correctly.