### PR TITLE
Fix creation of new directory

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
@@ -201,10 +201,26 @@ outputs:
                   - { 'path': /var/lib/opflex/files/mcast, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/droplog, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/faults, 'setype': svirt_sandbox_file_t }
-                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/sockets, 'setype': svirt_sandbox_file_t }
               when:
                 - not opflex_path.stat.exists
+
+            - name: Check for opflex restart directory
+              stat:
+                path: /var/lib/opflex/files/retarts
+              register: opflex_restart_path
+
+            - block:
+              - name: create restart directory, if needed
+                file:
+                  path: "{{ item.path }}"
+                  state: directory
+                  setype: "{{ item.setype }}"
+                  mode: "{{ item.mode|default(omit) }}"
+                with_items:
+                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
+              when:
+                - not opflex_restart_path.stat.exists
 
             - block:
               - name: Copy in cleanup script

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -218,10 +218,27 @@ outputs:
                   - { 'path': /var/lib/opflex/files/mcast, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/droplog, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/faults, 'setype': svirt_sandbox_file_t }
-                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/sockets, 'setype': svirt_sandbox_file_t }
               when:
                 - not opflex_path.stat.exists
+
+            - name: Check for opflex restart directory
+              stat:
+                path: /var/lib/opflex/files/retarts
+              register: opflex_restart_path
+
+            - block:
+              - name: create restart directory, if needed
+                file:
+                  path: "{{ item.path }}"
+                  state: directory
+                  setype: "{{ item.setype }}"
+                  mode: "{{ item.mode|default(omit) }}"
+                with_items:
+                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
+              when:
+                - not opflex_restart_path.stat.exists
+
 
             - name: create persistent logs directory for cisco opflex agent
               file:


### PR DESCRIPTION
The restarts subdirectory wasn't getting created on minor updates.
This is because the condition only checks for the parent directory,
which would have been created from a previous release. This patch
moves the new directory to its own block with its own precondition,
in order to ensure that the upgrade happens.