### PR TITLE
Fix opflex restarts

### DIFF
--- a/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_neutron_opflex.yaml
@@ -166,10 +166,24 @@ outputs:
                   - { 'path': /var/lib/opflex/files/mcast, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/droplog, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/faults, 'setype': svirt_sandbox_file_t }
-                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/sockets, 'setype': svirt_sandbox_file_t }
               when:
                 - not opflex_path.stat.exists
+            - name: Check for opflex restart directory
+              stat:
+                path: /var/lib/opflex/files/restarts
+              register: opflex_restart_path
+            - block:
+              - name: create opflex restart directory
+                file:
+                  path: "{{ item.path }}"
+                  state: directory
+                  setype: "{{ item.setype }}"
+                  mode: "{{ item.mode|default(omit) }}"
+                with_items:
+                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
+              when:
+                - not opflex_restart_path.stat.exists
 
       upgrade_tasks:
         list_concat:

--- a/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
+++ b/tripleo-ciscoaci/docker/services/cisco_opflex.yaml
@@ -167,10 +167,24 @@ outputs:
                   - { 'path': /var/lib/opflex/files/mcast, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/droplog, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/faults, 'setype': svirt_sandbox_file_t }
-                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/sockets, 'setype': svirt_sandbox_file_t }
               when:
                 - not opflex_path.stat.exists
+            - name: Check for opflex restart directory
+              stat:
+                path: /var/lib/opflex/files/restarts
+              register: opflex_restart_path
+            - block:
+              - name: create opflex restart directory
+                file:
+                  path: "{{ item.path }}"
+                  state: directory
+                  setype: "{{ item.setype }}"
+                  mode: "{{ item.mode|default(omit) }}"
+                with_items:
+                  - { 'path': /var/lib/opflex/files/restarts, 'setype': svirt_sandbox_file_t }
+              when:
+                - not opflex_restart_path.stat.exists
 
             - name: create persistent logs directory for cisco opflex agent
               file:


### PR DESCRIPTION
The restarts subdirectory wasn't getting created on minor updates.
This is because the condition only checks for the parent directory,
which would have been created from a previous release. This patch
moves the new directory to its own block with its own precondition,
in order to ensure that the upgrade happens.