### PR TITLE
Fix tags and sources for rsyslog

### DIFF
--- a/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
@@ -53,18 +53,8 @@ parameters:
   AciAimAidLoggingSource:
     type: json
     default:
-      tag: openstack.neutron.server
+      tag: ciscoaci.aim
       file: /var/log/containers/aim/aim-aid.log
-  AciAimRpcLoggingSource:
-    type: json
-    default:
-      tag: openstack.neutron.server
-      file: /var/log/containers/aim/aim-event-service-rpc.log
-  AciAimPollingLoggingSource:
-    type: json
-    default:
-      tag: openstack.neutron.server
-      file: /var/log/containers/aim/aim-event-service-polling.log
   NeutronApiOptVolumes:
     default: []
     description: list of optional volumes to be mounted
@@ -287,7 +277,7 @@ outputs:
   role_data:
     description: Role data for the Aci AIM role.
     value:
-      service_name: neutron_plugin_ciscoaci
+      service_name: ciscoaci_aim
       config_settings:
         map_merge:
           - get_attr: [NeutronMl2Base, role_data, config_settings]
@@ -350,8 +340,6 @@ outputs:
           - rsyslog:
               tripleo_logging_sources_ciscoaci_aim:
                 - {get_param: AciAimAidLoggingSource}
-                - {get_param: AciAimRpcLoggingSource}
-                - {get_param: AciAimPollingLoggingSource}
       puppet_config:
         config_volume: aim
         puppet_tags: aim_conf,aimctl_config

--- a/tripleo-ciscoaci/deployment/lldp/cisco_lldp.yaml
+++ b/tripleo-ciscoaci/deployment/lldp/cisco_lldp.yaml
@@ -40,12 +40,7 @@ parameters:
   CiscoAciLldpLoggingSource:
     type: json
     default:
-      tag: openstack.neutron.server
-      file: /var/log/containers/neutron/cisco-apic-host-agent.log
-  CiscoAciLldpSupervisordLoggingSource:
-    type: json
-    default:
-      tag: openstack.neutron.server
+      tag: ciscoaci.lldp
       file: /var/log/containers/neutron/cisco-apic-host-agent.log
 
 resources:
@@ -66,14 +61,13 @@ outputs:
   role_data:
     description: Role data for Cisco Aci LLDP service
     value:
-      service_name: ciscoaci_lldp_service
+      service_name: ciscoaci_lldp
       service_config_settings:
         map_merge:
           - get_attr: [NeutronBase, role_data, service_config_settings]
           - rsyslog:
               tripleo_logging_sources_ciscoaci_lldp:
                 - {get_param: CiscoAciLldpLoggingSource}
-                - {get_param: CiscoAciLldpSupervisordLoggingSource}
       puppet_config:
         config_volume: neutron
         puppet_tags: 

--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
@@ -47,7 +47,7 @@ parameters:
   NeutronOpflexAgentLoggingSource:
     type: json
     default:
-      tag: openstack.neutron.agent
+      tag: openstack.neutronopflex.controlleragent
       file: /var/log/containers/neutron/neutron-opflex-agent.log
   NeutronBridgeMappings:
     description: >
@@ -118,7 +118,7 @@ outputs:
         map_merge:
           - get_attr: [NeutronBase, role_data, service_config_settings]
           - rsyslog:
-              tripleo_logging_sources_neutron_opflex_agent:
+              tripleo_logging_sources_neutron_opflex_controller_agent:
                 - {get_param: NeutronOpflexAgentLoggingSource}
       puppet_config:
         config_volume: neutron_opflex

--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
@@ -47,7 +47,7 @@ parameters:
   NeutronOpflexAgentLoggingSource:
     type: json
     default:
-      tag: openstack.neutron.agent
+      tag: openstack.neutronopflex.agent
       file: /var/log/containers/neutron/neutron-opflex-agent.log
   NeutronBridgeMappings:
     description: >

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -40,17 +40,17 @@ parameters:
   OpflexAgentLoggingSource:
     type: json
     default:
-      tag: openstack.neutron.agent
+      tag: openstack.opflex.agent
       file: /var/log/containers/opflex/opflex-agent.log
   McastAgentLoggingSource:
     type: json
     default:
-      tag: openstack.opflex.agent
+      tag: openstack.opflex.mcastagent
       file: /var/log/containers/opflex/mcast.log
   OpflexSupervisordLoggingSource:
     type: json
     default:
-      tag: openstack.opflex.agent
+      tag: openstack.opflex.supervisord
       file: /var/log/containers/opflex/opflex-supervisord.log
   ACIOpflexUplinkInterface:
     type: string
@@ -160,7 +160,9 @@ outputs:
           - rsyslog:
               tripleo_logging_sources_opflex_agent:
                 - {get_param: OpflexAgentLoggingSource}
+              tripleo_logging_sources_opflex_mcast_agent:
                 - {get_param: McastAgentLoggingSource}
+              tripleo_logging_sources_opflex_supervisord:
                 - {get_param: OpflexSupervisordLoggingSource}
       puppet_config:
         config_volume: opflex


### PR DESCRIPTION
The rsyslog support in the tripleo project only allows for collection of
a single log file per service, so our templates needed to pick the most
important log file to export.. We also had incorrect names for the AIM
and LLDP services.