### PR TITLE
Add support for configuration of async JSON parser

### DIFF
--- a/tripleo-ciscoaci/puppet/services/ciscoaci-aim.yaml
+++ b/tripleo-ciscoaci/puppet/services/ciscoaci-aim.yaml
@@ -216,6 +216,14 @@ parameters:
   OpflexLoggingLevel:
     default: debug2
     type: string
+  OpflexEnableOvsdbAsyncParser:
+    default: false
+    description: Enable new asynchronous parsing of messaging interface with OVSDB
+    type: boolean
+  OpflexEnableOpflexAsyncParser:
+    default: false
+    description: Enable new asynchronous parsing of messaging interface with OpFlex
+    type: boolean
   AciVmmMcastRanges:
     type: string
     default: "225.2.1.1:225.2.255.255"
@@ -304,6 +312,8 @@ outputs:
             ciscoaci::opflex::opflex_log_level: {get_param: OpflexLoggingLevel}
             ciscoaci::aim_config::mcast_ranges: {get_param: AciVmmMcastRanges}
             ciscoaci::aim_config::multicast_address: {get_param: AciVmmMulticastAddress}
+            ciscoaci::opflex::opflex_ovsdb_async_parser: {get_param: OpflexEnableOvsdbAsyncParser}
+            ciscoaci::opflex::opflex_opflex_async_parser: {get_param: OpflexEnableOpflexAsyncParser}
       step_config: |
         include tripleo::profile::base::ciscoaci_aim
       metadata_settings:

--- a/tripleo-ciscoaci/puppet/services/ciscoaci_compute.yaml
+++ b/tripleo-ciscoaci/puppet/services/ciscoaci_compute.yaml
@@ -82,6 +82,14 @@ parameters:
   AciOpenvswitch:
     type: boolean
     default: false
+  OpflexEnableOvsdbAsyncParser:
+    default: false
+    description: Enable new asynchronous parsing of messaging interface with OVSDB
+    type: boolean
+  OpflexEnableOpflexAsyncParser:
+    default: false
+    description: Enable new asynchronous parsing of messaging interface with OpFlex
+    type: boolean
   IntelCnaNicDisableLLDP:
     type: boolean
     default: true
@@ -165,5 +173,7 @@ outputs:
             ciscoaci::compute::use_openvswitch: {get_param: AciOpenvswitch}
             ciscoaci::compute::intel_cna_nic_disable_lldp: {get_param: IntelCnaNicDisableLLDP}
             ciscoaci::opflex::neutron_external_bridge: {get_param: NeutronExternalBridge}
+            ciscoaci::opflex::opflex_ovsdb_async_parser: {get_param: OpflexEnableOvsdbAsyncParser}
+            ciscoaci::opflex::opflex_opflex_async_parser: {get_param: OpflexEnableOpflexAsyncParser}
       step_config: |
         include tripleo::profile::base::ciscoaci_compute


### PR DESCRIPTION
Allow users to configure whether or not to enable the new asynchronous JSON parser for OVSDB and OpFlex interfaces. Default is disabled for both, keeping existing behaviors.