### PR TITLE
Fix keystone notification pool

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
+++ b/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
@@ -200,14 +200,14 @@ parameters:
       determines which topic to use for notifications.
   AciKeystoneNotificationPool:
     type: string
-    default: None
+    default: ''
     description: >
       When AciKeystoneNotificationPurge is set to true,
       determines which pool to use for notifications.
       This value should only be configured to a value other
-      than 'None' when there are other notification listeners
+      than '' when there are other notification listeners
       subscribed to the same keystone exchange and topic, whose
-      pool is set to 'None'.
+      pool is set to ''.
   AciOpenvswitch:
     type: boolean
     default: false


### PR DESCRIPTION
Commit 474713b introduced the ability to configure the pool used for listening for notifications from Keystone. The default value used was None, but was incorrectly treated as a "None". The correct default should have been an empty string (''). This patch fixes the default setting.

Note that rabbitmq doesn't seem to automatically delete any old queues if they no longer have listeners, so they will have to be deleted manually.