### PR TITLE
Fix external upgrade

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
+++ b/tripleo-ciscoaci/deployment/neutron/neutron-ml2-ciscoaci.yaml
@@ -330,5 +330,9 @@ outputs:
             - system_upgrade_stop_services
           block:
             - name: Dummy
+              ignore_errors: true
+              file:
+                  path: /tmp/neutron_compute
+                  state: absent
               vars:
                 tripleo_delegate_to: "{{ groups['neutron_api'] | default([]) }}"

--- a/tripleo-ciscoaci/deployment/neutron_compute/ciscoaci_compute.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_compute/ciscoaci_compute.yaml
@@ -176,5 +176,9 @@ outputs:
             - system_upgrade_stop_services
           block:
             - name: Dummy2
+              ignore_errors: true
+              file:
+                  path: /tmp/neutron_compute
+                  state: absent
               vars:
                 tripleo_delegate_to: "{{ groups['neutron_api'] | default([]) }}"


### PR DESCRIPTION
Commit 952164b13d5b3e3785ea7880e8851215824a9348 fixed upgrades for train, but two of the playbooks were missing a module. This commit adds a module to those playbooks.