### PR TITLE
Fix regex for opflex agents

### DIFF
--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -42,11 +42,13 @@ parameters:
     default:
       tag: openstack.opflex.agent
       file: /var/log/containers/opflex/opflex-agent.log
+      startmsg.regex: “^.[0-9]{4}-[a-zA-Z]{3}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?] .(debug|info|warning|info|error)]”
   McastAgentLoggingSource:
     type: json
     default:
       tag: openstack.opflex.mcastagent
       file: /var/log/containers/opflex/mcast.log
+      startmsg.regex: “^.[0-9]{4}-[a-zA-Z]{3}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?] .(debug|info|warning|info|error)]”
   OpflexSupervisordLoggingSource:
     type: json
     default:


### PR DESCRIPTION
The opflex_agent and mcast_daemon use a different format for log messages. Configure a default for the regex that works for these agents.