### PR TITLE
Add GARP configuration for gen1 hardware

### DIFF
--- a/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/aciaim/cisco-aciaim-container-puppet.yaml
@@ -265,6 +265,14 @@ parameters:
   AciVmmMulticastAddress:
     type: string
     default: "225.1.2.3"
+  AciGen1HwGratArps:
+    type: boolean
+    default: false
+    description: >
+       First generation switch hardware cannot rely on gratiuitous ARPs for
+       EP move detection, when the move is within the same port. Set this flag
+       to True to ensure that gratuitous ARPs are sent go first generation
+       switch CPUs, in order to properly handle this type of EP move detection.
 
 conditions:
   fast_forward_upgrade: {not: {equals: [{get_param: ContainerCiscoAciAimImageStein},'']}}
@@ -348,6 +356,7 @@ outputs:
             ciscoaci::aim_config::rabbit_password: {get_param: RabbitPassword}
             ciscoaci::aim_config::rabbit_user: {get_param: RabbitUserName}
             ciscoaci::aim_config::rabbit_port: {get_param: RabbitClientPort}
+            ciscoaci::aim_config::gen1_hw_gratarps: {get_param: AciGen1HwGratArps}
       # BEGIN DOCKER SETTINGS
       service_config_settings:
         map_merge:


### PR DESCRIPTION
First generation switches are unable to use GARPs for EP movement detection in hardware when the EP "move" is on the same port..As a result, additional configuraiton is needed in the BD to punt all GARPs to the switch CPU for processing. This patch adds a tripleo parameter to control how this behavior is configured in the fabric, with the default configuration to disable it (i.e. default is to not support use of GARPs for EP movement detection on gen1 hardware).