### PR TITLE
Fix gbp_inspect collection

### DIFF
--- a/tripleo-ciscoaci/tools/report_vars.yaml
+++ b/tripleo-ciscoaci/tools/report_vars.yaml
@@ -5,8 +5,8 @@
         cmd: lldpctl
         ofile: aim/lldpctl
       dmtree:
-        container: ciscoaci_opflex_agent
-        cmd: gbp_inspect -fpr -t dump -q DmtreeRoot
+        container: -tu root ciscoaci_opflex_agent
+        cmd: gbp_inspect  --socket=/var/run/opflex/opflex-agent-inspect.sock -fpr -t dump -q DmtreeRoot
         ofile: opflex/DmtreeRoot
       ipnetns:
         container: ciscoaci_opflex_agent


### PR DESCRIPTION
The host report needs to use root inside the container in order to collect the gbp_inspect data.