### PR TITLE
Add opflex policy playbooks

### DIFF
--- a/tripleo-ciscoaci/tools/opflex_snapshot.yaml
+++ b/tripleo-ciscoaci/tools/opflex_snapshot.yaml
@@ -1,0 +1,7 @@
+---
+- name: Add new opflex-agent policy startup and switch sync configuration
+  hosts: overcloud
+  become: true
+  tasks:
+  - name: Add the opflex-agent policy startup configuration
+    shell: podman exec -u root ciscoaci_opflex_agent gbp_inspect -fprq DmtreeRoot -t dump --socket /var/run/opflex/opflex-agent-inspect.sock > /var/lib/opflex/files/policy/pol.json

--- a/tripleo-ciscoaci/tools/remove_opflex_policy.yaml
+++ b/tripleo-ciscoaci/tools/remove_opflex_policy.yaml
@@ -1,0 +1,10 @@
+---
+- name: Remove new opflex-agent policy startup and switch sync configuration
+  hosts: overcloud
+  become: true
+  tasks:
+  - name: Remove the opflex-agent policy startup configuration
+    file:
+      path: "/var/lib/opflex/files/policy/pol.json"
+      state: absent
+

--- a/tripleo-ciscoaci/tools/restart_opflex.yaml
+++ b/tripleo-ciscoaci/tools/restart_opflex.yaml
@@ -1,0 +1,9 @@
+---
+- name: Locking the environment to a Red Hat Enterprise Linux release
+  hosts: overcloud
+  become: true
+  tasks:
+  - name: Restart tripleo_ciscoaci_opflex_agent  service, in all cases
+    ansible.builtin.service:
+      name: tripleo_ciscoaci_opflex_agent
+      state: restarted

--- a/tripleo-ciscoaci/tools/update_tripelo.yaml
+++ b/tripleo-ciscoaci/tools/update_tripelo.yaml
@@ -1,0 +1,22 @@
+---
+- name: Install Cisco tripleo code
+  hosts: undercloud
+  tasks:
+  - name: Step1. Remove old Cisco tripleo RPM, if present
+    become: yes
+    yum:
+      name: tripleo-ciscoaci
+      state: absent
+    ignore_errors: true
+  - name: Step2. Remove the existing tripleo directories
+    become: yes
+    shell: rm -rf /opt/ciscoaci-tripleo-heat-templates /home/stack/tripleo-ciscoaci
+    ignore_errors: true
+  - name: Step3. Clone tripleo-ciscoaci
+    git:
+      repo: 'https://github.com/noironetworks/tripleo-ciscoaci.git'
+      dest: /home/stack/tripleo-ciscoaci
+      version: train
+  - name: Step4. Copy over the tripleo directory
+    become: yes
+    shell: cp -rp /home/stack/tripleo-ciscoaci/tripleo-ciscoaci /opt/ciscoaci-tripleo-heat-templates


### PR DESCRIPTION
Add playbooks that can be used to take a snapshot of opflex agent policy on all overcloud hosts, and restart the opflex agents on all overcloud hosts. There is also a playbook to remove the policy snapshot file.