### PR TITLE
Add directory for out of band configuration

### DIFF
--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -384,6 +384,7 @@ outputs:
                   - { 'path': /var/lib/opflex/files/droplog, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/faults, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/files/policy, 'setype': svirt_sandbox_file_t }
+                  - { 'path': /var/lib/opflex/files/outofband, 'setype': svirt_sandbox_file_t }
                   - { 'path': /var/lib/opflex/sockets, 'setype': svirt_sandbox_file_t }
               when:
                 - not opflex_path.stat.exists


### PR DESCRIPTION
The agent requires a new outofband directory. It's currently not used by OpenStack, but needs to be present on install.