### PR TITLE
Fix CVE from os-net-config

### DIFF
--- a/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
+++ b/tripleo-ciscoaci/tools/build_openstack_aci_containers.py
@@ -388,7 +388,7 @@ gpgcheck=0
             "rhel_container": "openstack-neutron-openvswitch-agent",
             "aci_container": "openstack-ciscoaci-opflex",
             "packages": [],
-            "run_cmds": ["yum --releasever={} -y install opflex-agent opflex-agent-renderer-openvswitch noiro-openvswitch-lib noiro-openvswitch-otherlib ciscoaci-puppet ethtool python3-neutron-opflex-agent python3-apicapi python3-openstack-neutron-gbp lldpd os-net-config".format(rhel_version)],
+            "run_cmds": ["yum --releasever={} -y install opflex-agent opflex-agent-renderer-openvswitch noiro-openvswitch-lib noiro-openvswitch-otherlib ciscoaci-puppet ethtool python3-neutron-opflex-agent python3-apicapi python3-openstack-neutron-gbp lldpd".format(rhel_version)],
             "osd_param_name": ["ContainerOpflexAgentImage"],
             "summary":"This is Ciscoaci Opflex Agent container",
             "description":"This will be deployed on the controller and compute nodes",


### PR DESCRIPTION
The osn-net-config isn't necessary for the opflex-agent container, and since it currently has a CVE against it, we are removing it from the container build.