### PR TITLE
Use iptables-nft

### DIFF
--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -477,14 +477,18 @@ outputs:
                 path: "/var/lib/opflex/files/droplog/a.droplogcfg"
                 state: absent
 
-            - name: Enable droplog in NFT
-              when: internal_droplog_enabled|bool
-              shell: nft add rule ip nat OUTPUT udp dport 6081 dnat 127.0.0.1:50000
-
-            - name: Disable droplog in NFT
-              when: not internal_droplog_enabled|bool
-              shell: nft delete rule ip nat OUTPUT handle $(nft -a list table ip nat | grep 6081 | awk '{print $NF}')
+            - name: Check for droplog rule in iptables
+              shell: iptables-nft -t nat --check OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000
+              register: rule_present
               ignore_errors: true
+
+            - name: Enable droplog in iptables
+              when: internal_droplog_enabled|bool and rule_present.stderr_lines
+              shell: iptables-nft -t nat -A OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000
+
+            - name: Disable droplog in iptables
+              when: not internal_droplog_enabled|bool and not rule_present.stderr_lines
+              shell: iptables-nft -t nat -D OUTPUT -p udp --dport 6081 -j DNAT --to 127.0.0.1:50000
 
             - name: Check for opflex restart directory
               stat:


### PR DESCRIPTION
Mixing  nft with iptables causes incompatibilities. Switch to using iptables-nft to avoid this conflict.