### PR TITLE
Fix openvswitch mounts

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
@@ -155,7 +155,7 @@ outputs:
         # on the unix domain socket - /run/openvswitch/db.sock
         volumes:
           - /lib/modules:/lib/modules:ro
-          - /run/openvswitch:/run/openvswitch
+          - /run/openvswitch:/run/openvswitch:shared,z
           - /etc/os-net-config:/etc/os-net-config:ro
       kolla_config:
         /var/lib/kolla/config_files/ciscoaci_neutron_opflex_agent.json:

--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
@@ -148,7 +148,7 @@ outputs:
         # on the unix domain socket - /run/openvswitch/db.sock
         volumes:
           - /lib/modules:/lib/modules:ro
-          - /run/openvswitch:/run/openvswitch
+          - /run/openvswitch:/run/openvswitch:shared,z
           - /etc/os-net-config:/etc/os-net-config:ro
       kolla_config:
         /var/lib/kolla/config_files/ciscoaci_neutron_opflex_agent.json:

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -350,7 +350,6 @@ outputs:
                   - /var/lib/config-data/puppet-generated/neutron/etc/neutron/metadata_agent.ini:/etc/neutron/metadata_agent.ini:ro
                   - /var/log/containers/opflex:/var/log/opflex
                   - /var/log/containers/neutron:/var/log/neutron
-                  - /var/run/openvswitch/:/var/run/openvswitch/:shared,z
                   - /run/netns:/run/netns:shared
                   - /lib/modules:/lib/modules:ro
                   - /var/lib/opflex/files:/var/lib/opflex-agent-ovs:shared,z


### PR DESCRIPTION
The number of mounts for /run/openvswitch increases every time the container is restarted due to overlapping mounts.