### PR TITLE
Add creation of snats directory for opflex

### DIFF
--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet-controller.yaml
@@ -304,6 +304,17 @@ outputs:
                 setype: svirt_sandbox_file_t
               when:
                 - not  opflex_path_outofband.stat.exists
+            - name: Check for opflex snats directory
+              stat:
+                path: /var/lib/opflex/files/snats
+              register: opflex_path_snats
+            - name: create opflex snats directory
+              file:
+                path: /var/lib/opflex/files/snats
+                state: directory
+                setype: svirt_sandbox_file_t
+              when:
+                - not  opflex_path_snats.stat.exists
             - name: Check for opflex sockets directory
               stat:
                 path: /var/lib/opflex/sockets

--- a/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/neutron_opflex/neutron-opflex-agent-container-puppet.yaml
@@ -297,6 +297,17 @@ outputs:
                 setype: svirt_sandbox_file_t
               when:
                 - not  opflex_path_outofband.stat.exists
+            - name: Check for opflex snats directory
+              stat:
+                path: /var/lib/opflex/files/snats
+              register: opflex_path_snats
+            - name: create opflex snats directory
+              file:
+                path: /var/lib/opflex/files/snats
+                state: directory
+                setype: svirt_sandbox_file_t
+              when:
+                - not  opflex_path_snats.stat.exists
             - name: Check for opflex sockets directory
               stat:
                 path: /var/lib/opflex/sockets

--- a/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
+++ b/tripleo-ciscoaci/deployment/opflex/opflex-agent-container-puppet.yaml
@@ -466,6 +466,17 @@ outputs:
                 setype: svirt_sandbox_file_t
               when:
                 - not  opflex_path_outofband.stat.exists
+            - name: Check for opflex snats directory
+              stat:
+                path: /var/lib/opflex/files/snats
+              register: opflex_path_snats
+            - name: create opflex snats directory
+              file:
+                path: /var/lib/opflex/files/snats
+                state: directory
+                setype: svirt_sandbox_file_t
+              when:
+                - not  opflex_path_snats.stat.exists
             - name: Check for opflex sockets directory
               stat:
                 path: /var/lib/opflex/sockets


### PR DESCRIPTION
The distributed SNAT feature requires creation of the snats directory for the opflex agents.